### PR TITLE
CPU fallback using tract, different channel orders, value ranges, pixel orders etc.

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,7 +7,10 @@ license = "GPLv3"
 [dependencies]
 ndarray = { version = "0.15.4" }
 ndarray-ndimage = "0.2"
-wonnx = { git = "https://github.com/mayjs/wonnx.git", branch = "temporary_combination_for_neuratable" }
+wonnx = { git = "https://github.com/mayjs/wonnx.git", branch = "feature/implement_conv_transpose" }
 image = "0.24.2"
 thiserror = "1.0"
 log = "0.4.19"
+tract-core = "0.20.7"
+tract-onnx = "0.20.7"
+protobuf = "2.28.0"

--- a/backend/src/chunksize.rs
+++ b/backend/src/chunksize.rs
@@ -1,0 +1,25 @@
+#[derive(Debug, Clone, Copy)]
+pub struct ChunkSize {
+    pub width: usize,
+    pub height: usize,
+}
+
+impl ChunkSize {
+    pub fn as_pair(&self) -> (usize, usize) {
+        (self.height, self.width)
+    }
+
+    pub fn remaining_area_after_padding(&self, padding: usize) -> Self {
+        Self {
+            height: self.height - 2 * padding,
+            width: self.width - 2 * padding,
+        }
+    }
+
+    pub fn stepsize_with_overlap(&self, overlap: usize) -> Self {
+        Self {
+            height: self.height - overlap,
+            width: self.width - overlap,
+        }
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod image_chunk_iterator;
 pub mod image_processor;
 pub mod model_runner;
+pub mod model_value_range;
 
 mod chunksize;
 pub use chunksize::ChunkSize;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod image_chunk_iterator;
 pub mod image_processor;
+pub mod model_runner;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod image_chunk_iterator;
 pub mod image_processor;
 pub mod model_runner;
+
+mod chunksize;
+pub use chunksize::ChunkSize;

--- a/backend/src/model_runner.rs
+++ b/backend/src/model_runner.rs
@@ -4,7 +4,7 @@ use protobuf::Message;
 use thiserror::Error;
 use tract_onnx::prelude::*;
 use wonnx::{
-    onnx::{self, GraphProto},
+    onnx::GraphProto,
     utils::{DataTypeError, OutputTensor, Shape},
     Session,
 };

--- a/backend/src/model_runner.rs
+++ b/backend/src/model_runner.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+use protobuf::Message;
+use thiserror::Error;
+use tract_onnx::prelude::*;
+use wonnx::{
+    onnx::{self, GraphProto},
+    utils::{DataTypeError, OutputTensor, Shape},
+    Session,
+};
+
+#[derive(Debug, Error)]
+pub enum ModelRunnerError {
+    #[error("The model has too many inputs")]
+    ModelInputError,
+    #[error("The models input is unsupported (a [1,3,h,w] shaped input is required and h must be equal to w)")]
+    InvalidInputShape(Shape),
+    #[error("Could not read model parameters")]
+    ModelParameterError(#[from] DataTypeError),
+    #[error("The model has no suitable output")]
+    NoSuitableOutput,
+    #[error("The model is not parseable")]
+    ParseError(#[from] protobuf::ProtobufError),
+}
+
+pub struct WonnxRunner {
+    session: Session,
+    input_name: String,
+    output_name: String,
+    input_scratchpad: ndarray::Array3<f32>,
+}
+
+pub struct TractRunner {
+    model: Box<dyn Fn(&ndarray::Array3<f32>) -> ndarray::Array3<f32>>,
+    input_scratchpad: ndarray::Array3<f32>,
+}
+
+pub enum ModelRunnerBackend {
+    WonnxRunner(WonnxRunner),
+    TractRunner(TractRunner),
+}
+
+pub struct ModelRunner {
+    backend: ModelRunnerBackend,
+    chunksize: usize,
+}
+
+impl ModelRunner {
+    pub fn get_chunksize(&self) -> usize {
+        self.chunksize
+    }
+
+    fn get_graph_input(graph: &GraphProto) -> Result<(Shape, String), ModelRunnerError> {
+        let inputs = graph.get_input();
+
+        if inputs.len() > 1 {
+            return Err(ModelRunnerError::ModelInputError);
+        }
+        let input_shape = inputs[0].get_shape()?;
+        let input_name = inputs[0].get_name().to_owned();
+
+        if input_shape.dim(0) != 1
+            || input_shape.dim(1) != 3
+            || input_shape.dim(2) != input_shape.dim(3)
+        {
+            return Err(ModelRunnerError::InvalidInputShape(input_shape));
+        }
+
+        Ok((input_shape, input_name))
+    }
+
+    fn get_matching_output(
+        graph: &GraphProto,
+        input_shape: &Shape,
+    ) -> Result<String, ModelRunnerError> {
+        graph
+            .get_output()
+            .iter()
+            .filter(|o| o.get_shape().map(|s| &s == input_shape).unwrap_or_default())
+            .next()
+            .map(|o| o.get_name().to_owned())
+            .ok_or_else(|| ModelRunnerError::NoSuitableOutput)
+    }
+
+    pub async fn new<R>(input: &mut R) -> Result<Self, ModelRunnerError>
+    where
+        R: std::io::Read + std::io::Seek,
+    {
+        let wonnx_model = wonnx::onnx::ModelProto::parse_from_reader(input)?;
+
+        let graph = wonnx_model.get_graph();
+        let (input_shape, input_name) = Self::get_graph_input(graph)?;
+        let output_name = Self::get_matching_output(graph, &input_shape)?;
+        log::info!("Using output {}", &output_name);
+        let chunksize = input_shape.dim(3) as usize;
+
+        match Session::from_model(wonnx_model).await {
+            Ok(session) => Ok(Self {
+                backend: ModelRunnerBackend::WonnxRunner(WonnxRunner {
+                    session,
+                    input_name,
+                    output_name,
+                    input_scratchpad: ndarray::Array3::<f32>::zeros((3, chunksize, chunksize)),
+                }),
+                chunksize,
+            }),
+            Err(err) => {
+                log::error!("Failed to create wonnx session: {}", err);
+                log::error!("Either wonnx doesn't support your model right now or you don't have Vulkan available. We will fall back to tract, but this will be slow!");
+
+                input.rewind().unwrap();
+
+                let tract_model = tract_onnx::onnx()
+                    .model_for_read(input)
+                    .unwrap()
+                    .into_optimized()
+                    .unwrap()
+                    .into_runnable()
+                    .unwrap();
+
+                let infer = move |input: &ndarray::Array3<f32>| {
+                    let shape = input.shape().clone();
+                    let mut result = tract_model
+                        .run(tvec![Into::<Tensor>::into(
+                            input
+                                .clone()
+                                .into_shape((1, shape[0], shape[1], shape[2]))
+                                .unwrap()
+                        )
+                        .into()])
+                        .unwrap();
+                    result
+                        .remove(0)
+                        .into_tensor()
+                        .into_array()
+                        .unwrap()
+                        .into_shape((shape[0], shape[1], shape[2]))
+                        .unwrap()
+                };
+
+                Ok(Self {
+                    backend: ModelRunnerBackend::TractRunner(TractRunner {
+                        model: Box::new(infer),
+                        input_scratchpad: ndarray::Array3::<f32>::zeros((3, chunksize, chunksize)),
+                    }),
+                    chunksize,
+                })
+            }
+        }
+    }
+
+    pub async fn process_chunk<'a>(
+        &mut self,
+        input: ndarray::ArrayView3<'a, f32>,
+    ) -> Result<ndarray::Array3<f32>, ModelRunnerError> {
+        match &mut self.backend {
+            ModelRunnerBackend::WonnxRunner(runner) => runner.process_chunk(input).await,
+            ModelRunnerBackend::TractRunner(runner) => runner.process_chunk(input).await,
+        }
+    }
+}
+
+impl WonnxRunner {
+    fn get_output_tensor(
+        &self,
+        network_result: &mut HashMap<String, OutputTensor>,
+        shape: &[usize],
+    ) -> ndarray::Array3<f32> {
+        if let OutputTensor::F32(data) = network_result.remove(&self.output_name).unwrap() {
+            ndarray::Array3::from_shape_vec((shape[0], shape[1], shape[2]), data).unwrap()
+        } else {
+            panic!("Unexpected output type!");
+        }
+    }
+
+    pub async fn process_chunk<'a>(
+        &mut self,
+        input: ndarray::ArrayView3<'a, f32>,
+    ) -> Result<ndarray::Array3<f32>, ModelRunnerError> {
+        input.assign_to(&mut self.input_scratchpad);
+        let input_map = HashMap::from([(
+            self.input_name.clone(),
+            self.input_scratchpad.as_slice().unwrap().into(),
+        )]);
+        let mut result = self.session.run(&input_map).await.unwrap();
+        Ok(self.get_output_tensor(&mut result, input.shape()))
+    }
+}
+
+impl TractRunner {
+    pub async fn process_chunk<'a>(
+        &mut self,
+        input: ndarray::ArrayView3<'a, f32>,
+    ) -> Result<ndarray::Array3<f32>, ModelRunnerError> {
+        input.assign_to(&mut self.input_scratchpad);
+        Ok((self.model)(&self.input_scratchpad))
+    }
+}

--- a/backend/src/model_runner.rs
+++ b/backend/src/model_runner.rs
@@ -11,11 +11,40 @@ use wonnx::{
 
 use crate::ChunkSize;
 
+pub enum ModelChannelOrder {
+    /// Batch, Channel, Height, Width order, this is the natural order for NeuraTable
+    NCHW,
+    /// Batch, Height, Width, Channel order, this will cause an additional permutation step
+    NHWC,
+}
+
+impl ModelChannelOrder {
+    fn translate_shape_to_chunksize(&self, shape: Shape) -> ChunkSize {
+        match self {
+            ModelChannelOrder::NCHW => ChunkSize {
+                width: shape.dim(3) as usize,
+                height: shape.dim(2) as usize,
+            },
+            ModelChannelOrder::NHWC => ChunkSize {
+                width: shape.dim(2) as usize,
+                height: shape.dim(1) as usize,
+            },
+        }
+    }
+
+    fn scratchpad_buffer_layout(&self, chunksize: ChunkSize) -> (usize, usize, usize) {
+        match self {
+            ModelChannelOrder::NCHW => (3, chunksize.height, chunksize.width),
+            ModelChannelOrder::NHWC => (chunksize.height, chunksize.width, 3),
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ModelRunnerError {
     #[error("The model has too many inputs")]
     ModelInputError,
-    #[error("The models input is unsupported (a [1,3,h,w] shaped input is required")]
+    #[error("The models input is unsupported. A [1,3,h,w] or [1,h,w,3] shaped input is required (NCHW or NHWC).")]
     InvalidInputShape(Shape),
     #[error("Could not read model parameters")]
     ModelParameterError(#[from] DataTypeError),
@@ -45,6 +74,7 @@ pub enum ModelRunnerBackend {
 pub struct ModelRunner {
     backend: ModelRunnerBackend,
     chunksize: ChunkSize,
+    model_channel_order: ModelChannelOrder,
 }
 
 impl ModelRunner {
@@ -52,7 +82,9 @@ impl ModelRunner {
         self.chunksize
     }
 
-    fn get_graph_input(graph: &GraphProto) -> Result<(Shape, String), ModelRunnerError> {
+    fn get_graph_input(
+        graph: &GraphProto,
+    ) -> Result<(Shape, String, ModelChannelOrder), ModelRunnerError> {
         let inputs = graph.get_input();
 
         if inputs.len() > 1 {
@@ -61,11 +93,21 @@ impl ModelRunner {
         let input_shape = inputs[0].get_shape()?;
         let input_name = inputs[0].get_name().to_owned();
 
-        if input_shape.dim(0) != 1 || input_shape.dim(1) != 3 {
+        if input_shape.dim(0) != 1 {
             return Err(ModelRunnerError::InvalidInputShape(input_shape));
         }
 
-        Ok((input_shape, input_name))
+        let channel_order = if input_shape.dim(1) == 3 {
+            log::debug!("NCHW model detected!");
+            ModelChannelOrder::NCHW
+        } else if input_shape.dim(3) == 3 {
+            log::debug!("NHWC model detected!");
+            ModelChannelOrder::NHWC
+        } else {
+            return Err(ModelRunnerError::InvalidInputShape(input_shape));
+        };
+
+        Ok((input_shape, input_name, channel_order))
     }
 
     fn get_matching_output(
@@ -88,13 +130,11 @@ impl ModelRunner {
         let wonnx_model = wonnx::onnx::ModelProto::parse_from_reader(input)?;
 
         let graph = wonnx_model.get_graph();
-        let (input_shape, input_name) = Self::get_graph_input(graph)?;
+        let (input_shape, input_name, model_channel_order) = Self::get_graph_input(graph)?;
+        log::info!("Detected model input shape: {:?}", input_shape);
         let output_name = Self::get_matching_output(graph, &input_shape)?;
         log::info!("Using output {}", &output_name);
-        let chunksize = ChunkSize {
-            height: input_shape.dim(2) as usize,
-            width: input_shape.dim(3) as usize,
-        };
+        let chunksize = model_channel_order.translate_shape_to_chunksize(input_shape);
 
         if !force_tract {
             match Session::from_model(wonnx_model).await {
@@ -104,13 +144,12 @@ impl ModelRunner {
                             session,
                             input_name,
                             output_name,
-                            input_scratchpad: ndarray::Array3::<f32>::zeros((
-                                3,
-                                chunksize.height,
-                                chunksize.width,
-                            )),
+                            input_scratchpad: ndarray::Array3::<f32>::zeros(
+                                model_channel_order.scratchpad_buffer_layout(chunksize),
+                            ),
                         }),
                         chunksize,
+                        model_channel_order,
                     })
                 }
                 Err(err) => {
@@ -131,6 +170,7 @@ impl ModelRunner {
 
         let infer = move |input: &ndarray::Array3<f32>| {
             let shape = input.shape().clone();
+            log::debug!("Running tract model with input shape {:?}", shape);
             let mut result = tract_model
                 .run(tvec![Into::<Tensor>::into(
                     input
@@ -152,13 +192,12 @@ impl ModelRunner {
         Ok(Self {
             backend: ModelRunnerBackend::TractRunner(TractRunner {
                 model: Box::new(infer),
-                input_scratchpad: ndarray::Array3::<f32>::zeros((
-                    3,
-                    chunksize.height,
-                    chunksize.width,
-                )),
+                input_scratchpad: ndarray::Array3::<f32>::zeros(
+                    model_channel_order.scratchpad_buffer_layout(chunksize),
+                ),
             }),
             chunksize,
+            model_channel_order,
         })
     }
 
@@ -166,10 +205,29 @@ impl ModelRunner {
         &mut self,
         input: ndarray::ArrayView3<'a, f32>,
     ) -> Result<ndarray::Array3<f32>, ModelRunnerError> {
-        match &mut self.backend {
-            ModelRunnerBackend::WonnxRunner(runner) => runner.process_chunk(input).await,
-            ModelRunnerBackend::TractRunner(runner) => runner.process_chunk(input).await,
-        }
+        log::debug!("Application order data shape: {:?}", input.shape());
+
+        // Input will be an ArrayView to an array of shape (CHW)
+        let model_order_input = match self.model_channel_order {
+            ModelChannelOrder::NCHW => input,
+            ModelChannelOrder::NHWC => input.permuted_axes([1, 2, 0]),
+        };
+
+        log::debug!("Model order data shape: {:?}", model_order_input.shape());
+
+        let model_output = match &mut self.backend {
+            ModelRunnerBackend::WonnxRunner(runner) => {
+                runner.process_chunk(model_order_input).await?
+            }
+            ModelRunnerBackend::TractRunner(runner) => {
+                runner.process_chunk(model_order_input).await?
+            }
+        };
+
+        Ok(match self.model_channel_order {
+            ModelChannelOrder::NCHW => model_output,
+            ModelChannelOrder::NHWC => model_output.permuted_axes([2, 0, 1]),
+        })
     }
 }
 

--- a/backend/src/model_value_range.rs
+++ b/backend/src/model_value_range.rs
@@ -1,0 +1,87 @@
+use std::{
+    ops::{AddAssign, DivAssign},
+    str::FromStr,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModelValueMode {
+    /// Values are centered on 0 (and have a negative and positive part)
+    Symmetric,
+    /// Values are not centered on zero and are positive
+    Asymmetric,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelValueRange {
+    value_mode: ModelValueMode,
+    max_abs_value: f32,
+}
+
+impl ModelValueRange {
+    /// Create a new symmetric model value range
+    pub fn symmetric(max_abs_value: f32) -> Self {
+        Self {
+            value_mode: ModelValueMode::Symmetric,
+            max_abs_value,
+        }
+    }
+
+    /// Create a new asymmetric model value range
+    pub fn asymmetric(max_abs_value: f32) -> Self {
+        Self {
+            value_mode: ModelValueMode::Asymmetric,
+            max_abs_value,
+        }
+    }
+
+    /// Transform a single value in the u16 range to a f32 value in the range specified by self
+    pub fn pixel_value_to_model(&self, pixel_value: u16) -> f32 {
+        let asymmetric_value = ((pixel_value as f32) / (u16::MAX as f32)) * self.max_abs_value;
+        match self.value_mode {
+            ModelValueMode::Symmetric => (asymmetric_value * 2.0) - self.max_abs_value,
+            ModelValueMode::Asymmetric => asymmetric_value,
+        }
+    }
+
+    /// Transform a value in the value range specified by self into the [0,1] range
+    pub fn normalize_model_value<T>(&self, model_value: &mut T)
+    where
+        T: AddAssign<f32> + DivAssign<f32>,
+    {
+        if self.value_mode == ModelValueMode::Symmetric {
+            *model_value += self.max_abs_value;
+            *model_value /= 2.0;
+        }
+
+        *model_value /= self.max_abs_value;
+    }
+}
+
+impl FromStr for ModelValueRange {
+    type Err = std::num::ParseFloatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with("+-") {
+            s[2..].parse().map(|max| ModelValueRange::symmetric(max))
+        } else {
+            s.parse().map(|max| ModelValueRange::asymmetric(max))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_symmetric() {
+        let parsed = ModelValueRange::from_str("+-123").unwrap();
+        assert_eq!(parsed, ModelValueRange::symmetric(123.0));
+    }
+
+    #[test]
+    fn test_parse_asymmetric() {
+        let parsed = ModelValueRange::from_str("1000.00").unwrap();
+        assert_eq!(parsed, ModelValueRange::asymmetric(1000.0));
+    }
+}

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPLv3"
 [dependencies]
 pollster = "0.3.0"
 backend = { path = "../backend" }
-wonnx = { git = "https://github.com/mayjs/wonnx.git", branch = "temporary_combination_for_neuratable" }
+wonnx = { git = "https://github.com/mayjs/wonnx.git", branch = "feature/implement_conv_transpose" }
 image = "0.24.2"
 protobuf = { version = "2.27.1", features = ["with-bytes"] }
 argh = "0.1.11"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -13,3 +13,4 @@ protobuf = { version = "2.27.1", features = ["with-bytes"] }
 argh = "0.1.11"
 env_logger = "0.10.0"
 log = "0.4.19"
+anyhow = "1.0"

--- a/desktop/src/bin/neuratable_run_onnx.rs
+++ b/desktop/src/bin/neuratable_run_onnx.rs
@@ -1,5 +1,23 @@
+use std::str::FromStr;
+
 use argh::FromArgs;
-use backend::image_processor::ImageProcessor;
+use backend::image_processor::{ImageColorModel, ImageProcessor, ModelValueRange};
+
+#[derive(Debug, Clone, PartialEq)]
+struct ArgColorModel(ImageColorModel);
+
+impl FromStr for ArgColorModel {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uppercase = s.to_uppercase();
+        Ok(match uppercase.as_ref() {
+            "BGR" => ArgColorModel(ImageColorModel::BGR),
+            "RGB" => ArgColorModel(ImageColorModel::RGB),
+            _ => anyhow::bail!("Color model {} not known, must be one of (RGB, BGR)", s),
+        })
+    }
+}
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// Run a 1:1 ONNX model in chunked mode
@@ -10,6 +28,9 @@ struct RunOnnx {
     input_image: String,
     #[argh(positional)]
     output_image: String,
+    /// the expected color channel order of the model
+    #[argh(option, default = "ArgColorModel(ImageColorModel::RGB)")]
+    model_channel_order: ArgColorModel,
     /// whether or not to force CPU processing
     #[argh(switch)]
     force_cpu: bool,
@@ -22,11 +43,24 @@ async fn run(args: RunOnnx) {
         .await
         .unwrap();
 
-    let mut processor = ImageProcessor::new(runner).await.unwrap();
+    // FIXME: These must be parsed from arguments
+    let input_range = ModelValueRange::asymmetric(255.0);
+    let output_range = ModelValueRange::asymmetric(255.0);
 
-    let input_image = image::open(&args.input_image).unwrap().to_rgb8();
+    let mut processor = ImageProcessor::new(
+        runner,
+        args.model_channel_order.0,
+        input_range,
+        output_range,
+    )
+    .await
+    .unwrap();
+
+    let input_image = image::open(&args.input_image).unwrap().to_rgb16();
     let output_image = processor.process_image(input_image).await.unwrap();
 
+    // FIXME: For JPG Output, we need to scale the image data back to 8 Bit RGB
+    // We need to find a generic way to solve this issue
     output_image.save(&args.output_image).unwrap();
 }
 

--- a/desktop/src/bin/neuratable_run_onnx.rs
+++ b/desktop/src/bin/neuratable_run_onnx.rs
@@ -1,6 +1,5 @@
-use backend::image_processor::ImageProcessor;
-use protobuf::Message;
 use argh::FromArgs;
+use backend::image_processor::ImageProcessor;
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// Run a 1:1 ONNX model in chunked mode
@@ -11,13 +10,17 @@ struct RunOnnx {
     input_image: String,
     #[argh(positional)]
     output_image: String,
+    /// whether or not to force CPU processing
+    #[argh(switch)]
+    force_cpu: bool,
 }
 
 async fn run(args: RunOnnx) {
     let mut r = std::fs::File::open(&args.onnx_model).unwrap();
-    //let model = wonnx::onnx::ModelProto::parse_from_bytes(&std::fs::read(&args.onnx_model).unwrap()).unwrap();
 
-    let runner = backend::model_runner::ModelRunner::new(&mut r).await.unwrap();
+    let runner = backend::model_runner::ModelRunner::new(&mut r, args.force_cpu)
+        .await
+        .unwrap();
 
     let mut processor = ImageProcessor::new(runner).await.unwrap();
 

--- a/desktop/src/bin/neuratable_run_onnx.rs
+++ b/desktop/src/bin/neuratable_run_onnx.rs
@@ -14,8 +14,12 @@ struct RunOnnx {
 }
 
 async fn run(args: RunOnnx) {
-    let model = wonnx::onnx::ModelProto::parse_from_bytes(&std::fs::read(&args.onnx_model).unwrap()).unwrap();
-    let processor = ImageProcessor::new(model).await.unwrap(); 
+    let mut r = std::fs::File::open(&args.onnx_model).unwrap();
+    //let model = wonnx::onnx::ModelProto::parse_from_bytes(&std::fs::read(&args.onnx_model).unwrap()).unwrap();
+
+    let runner = backend::model_runner::ModelRunner::new(&mut r).await.unwrap();
+
+    let mut processor = ImageProcessor::new(runner).await.unwrap();
 
     let input_image = image::open(&args.input_image).unwrap().to_rgb8();
     let output_image = processor.process_image(input_image).await.unwrap();

--- a/desktop/src/bin/neuratable_run_onnx.rs
+++ b/desktop/src/bin/neuratable_run_onnx.rs
@@ -1,7 +1,8 @@
 use std::str::FromStr;
 
 use argh::FromArgs;
-use backend::image_processor::{ImageColorModel, ImageProcessor, ModelValueRange};
+use backend::image_processor::{ImageColorModel, ImageProcessor};
+use backend::model_value_range::ModelValueRange;
 
 #[derive(Debug, Clone, PartialEq)]
 struct ArgColorModel(ImageColorModel);
@@ -34,6 +35,14 @@ struct RunOnnx {
     /// whether or not to force CPU processing
     #[argh(switch)]
     force_cpu: bool,
+    /// the value range for input values. Can be a positive float number for [0,x] ranges or "+-x"
+    /// for [-x,x] ranges
+    #[argh(option, default = "ModelValueRange::asymmetric(1.0)")]
+    input_range: ModelValueRange,
+    #[argh(option, default = "ModelValueRange::asymmetric(1.0)")]
+    /// the value range for output values. Can be a positive float number for [0,x] ranges or "+-x"
+    /// for [-x,x] ranges
+    output_range: ModelValueRange,
 }
 
 async fn run(args: RunOnnx) {
@@ -43,15 +52,11 @@ async fn run(args: RunOnnx) {
         .await
         .unwrap();
 
-    // FIXME: These must be parsed from arguments
-    let input_range = ModelValueRange::asymmetric(255.0);
-    let output_range = ModelValueRange::asymmetric(255.0);
-
     let mut processor = ImageProcessor::new(
         runner,
         args.model_channel_order.0,
-        input_range,
-        output_range,
+        args.input_range,
+        args.output_range,
     )
     .await
     .unwrap();


### PR DESCRIPTION
This PR adds broader support for models.
Not all of these new features are available on the CLI for now and we break JPG output compatibility due to a switch to full 16 Bit image handling.